### PR TITLE
Fix cog deployment template labels

### DIFF
--- a/templates/cog-deployment.yaml
+++ b/templates/cog-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "cog.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "cog.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"

--- a/templates/cog-deployment.yaml
+++ b/templates/cog-deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "cog.fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"


### PR DESCRIPTION
The `cog-service` defines:
```
selector:
    app: {{ template "cog.fullname" . }}
```

As such, the `cog-deployment` should attach correct label

```
spec:
  replicas: {{ .Values.cog.replicaCount }}
  template:
    metadata:
      labels:
        app: {{ template "cog.fullname" . }}
```