### PR TITLE
Specify relay-id in relay.config only

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ The following tables lists the required configuration variables. See the [values
 | -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
 | `cog.secrets.slackAPIToken`                   | API Token for connecting to Slack | None |
 | `cog.secrets.databaseURL`                | Database connection string | `ecto://cog:cog@postgres:5432/cog` |
+| `relay.config.relay-id` | Relay Id | `00000000-0000-0000-0000-000000000000`
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
 $ helm install --name my-release \
-  --set cog.secrets.slackAPIToken=token,cog.secrets.databaseURL=connection \
+  --set cog.secrets.slackAPIToken=token,cog.secrets.databaseURL=connection,relay.config.relay-id=$(uuidgen | tr '[:upper:]' '[:lower:]') \
     cog-helm
 ```
 

--- a/templates/cog-deployment.yaml
+++ b/templates/cog-deployment.yaml
@@ -76,6 +76,8 @@ spec:
             secretKeyRef:
               name: {{ template "relay.fullname" . }}
               key: relay-cog-token
+        - name: "RELAY_ID"
+          value: {{ index .Values.relay.config "relay-id" }}
       volumes:
       - name: {{ .Values.cog.name }}-data
         emptyDir: {}

--- a/values.yaml
+++ b/values.yaml
@@ -70,8 +70,6 @@ cog:
     cog-service-url-base: cog.example.com/service
     cog-trigger-url-base: cog.example.com/trigger
 
-    relay-id: 00000000-0000-0000-0000-000000000000
-
     ## These variables are used to configure an initial admin account
     # cog-bootstrap-chat-handle:
     cog-bootstrap-username: admin


### PR DESCRIPTION
This should simplify the management of the `RELAY_ID`