### PR TITLE
Specify a default version.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,7 @@ cog:
   replicaCount: 1
   image:
     repository: operable/cog
-    tag: latest
+    tag: 1.0.1
 
   resources:
     # limits:


### PR DESCRIPTION
Using the latest tag makes it difficult to upgrade and difficult to be certain which version one is running.